### PR TITLE
Added gettext flags to prevent 'libintl.h' file not found errors

### DIFF
--- a/Formula/postgresql@16.rb
+++ b/Formula/postgresql@16.rb
@@ -40,6 +40,10 @@ class PostgresqlAT16 < Formula
     ENV.prepend "LDFLAGS", "-L#{Formula["openssl@3"].opt_lib} -L#{Formula["readline"].opt_lib}"
     ENV.prepend "CPPFLAGS", "-I#{Formula["openssl@3"].opt_include} -I#{Formula["readline"].opt_include}"
 
+    # Fix 'libintl.h' file not found for extensions
+    ENV.prepend "LDFLAGS", "-L#{Formula["gettext"].opt_lib}"
+    ENV.prepend "CPPFLAGS", "-I#{Formula["gettext"].opt_include}"
+
     args = %W[
       --disable-debug
       --prefix=#{prefix}


### PR DESCRIPTION
I've been getting `'libintl.h' file not found errors` when trying to install the `pg_search` extension. I then compared the original Homebrew formula to the one in your tap and it had the changes in it that I added in this PR.